### PR TITLE
Removed obsolete objects entry

### DIFF
--- a/rootfs/etc/icinga2/icinga2.conf
+++ b/rootfs/etc/icinga2/icinga2.conf
@@ -10,6 +10,6 @@ include <plugins>
 include "features-enabled/*.conf"
 include_recursive "repository.d"
 include_recursive "conf.d"
-include_recursive "objects"
+// include_recursive "objects"
 
 // EOF


### PR DESCRIPTION
The objects entry in the configuration leads to an error starting up icinga2
during the configuration run.