### PR TITLE
Director-global Zone On Satellites

### DIFF
--- a/rootfs/init/pki_setup.sh
+++ b/rootfs/init/pki_setup.sh
@@ -322,6 +322,10 @@ object Zone "global-templates" {
   global = true
 }
 
+object Zone "director-global" {
+  global = true
+}
+
 EOF
   fi
 


### PR DESCRIPTION
When using the Icinga Directory the following warnings can be found on satellites:

```
Ignoring config update for unknown zone 'global-templates'
```

This prevent the syncing of any templates found within the `global-templates` zone (now included by default in recent versions of Icinga2). This pull adds that command directive back. 