### PR TITLE
Fixes Notifications Failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV \
   BUILD_DATE="2017-11-08" \
   BUILD_TYPE="stable" \
   CERT_SERVICE_VERSION="0.10.2" \
-  ICINGA_VERSION="2.7.1-r0" \
+  ICINGA_VERSION="2.7.1-r1" \
   APK_ADD="bind-tools ca-certificates curl fping g++ git inotify-tools jq libffi-dev make mailx monitoring-plugins mysql-client netcat-openbsd nmap nrpe-plugin openssl openssl-dev pwgen ruby ruby-dev s6 ssmtp unzip bash" \
   APK_DEL="libffi-dev g++ make git openssl-dev ruby-dev" \
   GEMS="io-console bundler"
@@ -43,6 +43,7 @@ RUN \
     --no-cache \
     --update-cache \
     --repository http://${ALPINE_MIRROR}/alpine/edge/community \
+    --repository http://${ALPINE_MIRROR}/alpine/edge/main \
     --allow-untrusted \
     add icinga2  && \
   #

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV \
   BUILD_TYPE="stable" \
   CERT_SERVICE_VERSION="0.10.2" \
   ICINGA_VERSION="2.7.1-r0" \
-  APK_ADD="bind-tools ca-certificates curl fping g++ git inotify-tools jq libffi-dev make mailx monitoring-plugins mysql-client netcat-openbsd nmap nrpe-plugin openssl openssl-dev pwgen ruby ruby-dev s6 ssmtp unzip" \
+  APK_ADD="bind-tools ca-certificates curl fping g++ git inotify-tools jq libffi-dev make mailx monitoring-plugins mysql-client netcat-openbsd nmap nrpe-plugin openssl openssl-dev pwgen ruby ruby-dev s6 ssmtp unzip bash" \
   APK_DEL="libffi-dev g++ make git openssl-dev ruby-dev" \
   GEMS="io-console bundler"
 


### PR DESCRIPTION
The following error can be seen in the logs when attempting to send a notification:

```
warning/PluginNotificationTask: Notification command for object 
with exit code 127, output: env: can't execute 'bash': No such file or directory
```

This pull does the following:
* Adds the bash dependency.
* Upgrades icinga2 to `2.7.1-r1` (breaking changes due to compiling against libressl)
  * https://git.alpinelinux.org/cgit/aports/commit/community/icinga2/APKBUILD?id=99c407a201e7aa9e4693d2e3402579da6ad22af6
  * Requires `libressl2.6-libcrypto` and `libressl2.6-libssl` only found in edge/main.

