### PR TITLE
fix small problem with syncronize the global-template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.7
 ENV \
   TERM=xterm \
   TZ='Europe/Berlin' \
-  BUILD_DATE="2018-01-23" \
+  BUILD_DATE="2018-01-24" \
   BUILD_TYPE="stable" \
   CERT_SERVICE_VERSION="0.16.5" \
   ICINGA_VERSION="2.8.0-r0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN \
   /usr/sbin/icinga2 feature enable command checker mainlog notification && \
   mkdir -p /etc/icinga2/objects.d && \
   mkdir -p /run/icinga2/cmd && \
+  mkdir -p /etc/icinga2/zones.d/global-templates && \
+  mkdir -p /etc/icinga2/zones.d/director-global && \
   cp /etc/icinga2/zones.conf /etc/icinga2/zones.conf-distributed && \
   chmod u+s /bin/busybox && \
   echo 'gem: --no-document' >> /etc/gemrc && \

--- a/docker-compose_example.yml
+++ b/docker-compose_example.yml
@@ -1,6 +1,14 @@
 ---
 version: '3.3'
 
+networks:
+  frontend:
+  backend:
+  database:
+  satellite:
+
+
+
 services:
 
   database:
@@ -13,6 +21,8 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /tmp/docker-data/database:/srv
+    networks:
+      - database
 
   # icingaweb2
   #
@@ -37,6 +47,12 @@ services:
     links:
       - icinga2-master:icinga2-master.matrix.lan
       - database
+    extra_hosts:
+      - dl-cdn.alpinelinux.org:192.168.0.20
+    networks:
+      - database
+      - frontend
+      - backend
 
   # the Icinga2 Master
   # includes a certificate service to create and provide a icinga certificate
@@ -75,6 +91,12 @@ services:
 #      - /tmp/docker-data/icinga2-master:/var/lib/icinga2
     links:
       - database
+    extra_hosts:
+      - dl-cdn.alpinelinux.org:192.168.0.20
+    networks:
+      - database
+      - backend
+
 
   # the first icinga2 satellite
   # ask the master above for an certificate
@@ -100,7 +122,9 @@ services:
       - /etc/localtime:/etc/localtime:ro
     links:
       - icinga2-master:icinga2-master.matrix.lan
-
+    networks:
+      - backend
+      - satellite
 
   # the second icinga2 satellite
   # ask the master above for an certificate

--- a/rootfs/etc/icinga2/master.d/templates_services.conf
+++ b/rootfs/etc/icinga2/master.d/templates_services.conf
@@ -11,3 +11,21 @@ template Service "icinga-satellite-service" {
   command_endpoint    = host.vars.remote_endpoint
   zone                = host.vars.remote_endpoint
 }
+
+template Host "default-host-ping" {
+  check_command        = "ping4"
+  max_check_attempts   = 5
+  check_interval       = 3m
+  retry_interval       = 2m
+
+/*
+  check_period         = host.vars.check_period  "24x7"
+  enable_notifications = true
+  vars.fping_wrta      = 1000
+  vars.fping_wpl       = 100
+  vars.fping_crta      = 2000
+  vars.fping_cpl       = 100
+  vars.fping_number    = 2
+  vars.fping_interval  = 500
+*/
+}

--- a/rootfs/init/common.sh
+++ b/rootfs/init/common.sh
@@ -64,8 +64,8 @@ prepare() {
 
   # create global zone directories for distributed monitoring
   #
-  [[ -d /etc/icinga2/zones.d/global-templates ]] || mkdir -p /etc/icinga2/zones.d/global-templates
-  [[ -d /etc/icinga2/zones.d/director-global ]] || mkdir -p /etc/icinga2/zones.d/director-global
+  # [[ -d /etc/icinga2/zones.d/global-templates ]] || mkdir -p /etc/icinga2/zones.d/global-templates
+  # [[ -d /etc/icinga2/zones.d/director-global ]] || mkdir -p /etc/icinga2/zones.d/director-global
 
   # create directory for the logfile and change rights
   #

--- a/rootfs/init/icinga_types/satellite.sh
+++ b/rootfs/init/icinga_types/satellite.sh
@@ -222,12 +222,19 @@ EOF
   then
     log_info "CA from our master replicated"
 
-    # we must also replace the zone configuration
-    # with our icinga-master as parent to report checks
-    log_info "  replace the static zone config"
-    sed -i \
-      -e 's|^object Zone ZoneName.*}$|object Zone ZoneName { endpoints = [ NodeName ]; parent = "master" }|g' \
-      ${zones_file}
+    # TODO
+    # detect the Endpoint for this zone
+    if [[ -f ${api_endpoint} ]]
+    then
+      log_info "  endpoint also replicated"
+
+      # we must also replace the zone configuration
+      # with our icinga-master as parent to report checks
+      log_info "  replace the static zone config"
+      sed -i \
+        -e 's|^object Zone ZoneName.*}$|object Zone ZoneName { endpoints = [ NodeName ]; parent = "master" }|g' \
+        ${zones_file}
+    fi
   fi
 
   # finaly, we create the backup

--- a/rootfs/init/icinga_types/satellite.sh
+++ b/rootfs/init/icinga_types/satellite.sh
@@ -149,15 +149,21 @@ endpoint_configuration() {
 
     cp ${backup_zones_file} ${zones_file}
 
-    if [[ ! -z ${ICINGA_MASTER_NAME} ]]
+    master_json="${ICINGA_LIB_DIR}/backup/sign_${HOSTNAME}.json"
+
+    if [[ -f ${master_json} ]]
     then
-      log_info "use remote master name '${ICINGA_MASTER_NAME}'"
+      message=$(jq --raw-output .message ${master_json} 2> /dev/null)
+      master_name=$(jq --raw-output .master_name ${master_json} 2> /dev/null)
+      master_ip=$(jq --raw-output .master_ip ${master_json} 2> /dev/null)
+
+      log_info "use remote master name '${master_name}'"
 
       # locate the Endpoint and the Zone for our Master and replace the original
       # entrys with the new one
       sed -i \
-        -e 's/^\(object Endpoint\) "[^"]*"/\1 \"'$ICINGA_MASTER_NAME'\"/' \
-        -e 's/\(\[\) "[^"]*" \(\]\)/\1 \"'$ICINGA_MASTER_NAME'\" \2/' \
+        -e 's/^\(object Endpoint\) "[^"]*"/\1 \"'$master_name'\"/' \
+        -e 's/\(\[\) "[^"]*" \(\]\)/\1 \"'$master_name'\" \2/' \
       ${zones_file}
     fi
   fi
@@ -279,20 +285,15 @@ request_certificate_from_master() {
 
     if ( [[ $? -eq 0 ]] && [[ ${code} == 200 ]] )
     then
-
-      cat /tmp/sign_${HOSTNAME}.json
-
       message=$(jq --raw-output .message /tmp/sign_${HOSTNAME}.json 2> /dev/null)
       master_name=$(jq --raw-output .master_name /tmp/sign_${HOSTNAME}.json 2> /dev/null)
       master_ip=$(jq --raw-output .master_ip /tmp/sign_${HOSTNAME}.json 2> /dev/null)
 
-      rm -f /tmp/sign_${HOSTNAME}.json
+      mv /tmp/sign_${HOSTNAME}.json ${ICINGA_LIB_DIR}/backup/
+
       log_info "${message}"
       log_info "  - ${master_name}"
       log_info "  - ${master_ip}"
-
-      export ICINGA_MASTER_NAME=${master_name}
-      export ICINGA_MASTER_IP=${master_ip}
 
       sleep 5s
 
@@ -367,9 +368,17 @@ configure_icinga2_satellite() {
 
   request_certificate_from_master
 
-  ( [[ -d /etc/icinga2/zones.d/global-templates ]] && [[ -f /etc/icinga2/master.d/templates_services.conf ]] ) && cp /etc/icinga2/master.d/templates_services.conf /etc/icinga2/zones.d/global-templates/
   [[ -f /etc/icinga2/satellite.d/services.conf ]] && cp /etc/icinga2/satellite.d/services.conf /etc/icinga2/conf.d/
   [[ -f /etc/icinga2/satellite.d/commands.conf ]] && cp /etc/icinga2/satellite.d/commands.conf /etc/icinga2/conf.d/satellite_commands.conf
+
+  # REALLY BAD HACK ..
+  # copy the inline templates direct into the API path
+  #
+  if [[ ! -d /var/lib/icinga2/api/zones/global-templates/_etc/ ]]
+  then
+    mkdir -p /var/lib/icinga2/api/zones/global-templates/_etc/
+    cp -a /etc/icinga2/master.d/templates_services.conf /var/lib/icinga2/api/zones/global-templates/_etc/
+  fi
 
   correct_rights
 

--- a/rootfs/init/runtime/zone_watcher.sh
+++ b/rootfs/init/runtime/zone_watcher.sh
@@ -64,16 +64,7 @@ inotifywait \
         cp /etc/icinga2/zones.conf ${ICINGA_LIB_DIR}/backup/zones.conf
 
         log_info "we remove also the static global-templates directory"
-        if [[ -d /etc/icinga2/zones.d/global-templates ]]
-        then
-          for template in $(ls -1 /etc/icinga2/zones.d/global-templates/*)
-          do
-            name=$(basename ${template})
-            [[ -f /var/lib/icinga2/api/zones/global-templates/_etc/${base} ]] || cp -v ${template} /var/lib/icinga2/api/zones/global-templates/_etc/
-          done
-
-          rm -rf /etc/icinga2/zones.d/global-templates
-        fi
+        [[ -d /etc/icinga2/zones.d/global-templates ]] && rm -rf /etc/icinga2/zones.d/global-templates
 
         log_info "we remove also the static director-global directory"
         [[ -d /etc/icinga2/zones.d/director-global ]] && rm -rf /etc/icinga2/zones.d/director-global

--- a/rootfs/init/runtime/zone_watcher.sh
+++ b/rootfs/init/runtime/zone_watcher.sh
@@ -63,6 +63,21 @@ inotifywait \
 
         cp /etc/icinga2/zones.conf ${ICINGA_LIB_DIR}/backup/zones.conf
 
+        log_info "we remove also the static global-templates directory"
+        if [[ -d /etc/icinga2/zones.d/global-templates ]]
+        then
+          for template in $(ls -1 /etc/icinga2/zones.d/global-templates/*)
+          do
+            name=$(basename ${template})
+            [[ -f /var/lib/icinga2/api/zones/global-templates/_etc/${base} ]] || cp -v ${template} /var/lib/icinga2/api/zones/global-templates/_etc/
+          done
+
+          rm -rf /etc/icinga2/zones.d/global-templates
+        fi
+
+        log_info "we remove also the static director-global directory"
+        [[ -d /etc/icinga2/zones.d/director-global ]] && rm -rf /etc/icinga2/zones.d/director-global
+
         # touch file for later add the satellite to the master over API
         #
         touch /tmp/add_host
@@ -70,6 +85,7 @@ inotifywait \
 
         # kill myself to finalize
         #
+        killall icinga2
         exit 1
       fi
     fi


### PR DESCRIPTION
- add new template for a satellite-host
  now, i have an small problem with syncronize the global-template
- use seperate networks in the docker-compose example to simulate ... network
  - only for the satellite
- copy inline template config direct into the PAI path (bad hack)
- use the sign.json for replace the icinga2-master name in the Endpoint config