### PR TITLE
added ICINGA2_VERSION default var to Makefile, added to README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ REPO     := docker-icinga2
 BUILD_DATE := $(shell date +%Y-%m-%d)
 
 ICINGA2_VERSION ?= latest
+export
 
 default:
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ REPO     := docker-icinga2
 
 BUILD_DATE := $(shell date +%Y-%m-%d)
 
+ICINGA2_VERSION ?= latest
+
 default:
 	@echo ""
 	@echo "Targets:"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ creates several containers with different icinga2 characteristics:
 
 
 # Build
-Your can use the included Makefile.
+You can use the included Makefile.
 - To build the Container: `make`
 - To remove the builded Docker Image: `make clean`
 - Starts the Container: `make run`
@@ -29,6 +29,8 @@ Your can use the included Makefile.
 - Entering the Container: `make exec`
 - Stop (but **not kill**): `make stop`
 - History `make history`
+
+_You can specify an image version by using the `ICINGA2_VERSION` environment variable (This defaults to the "latest" tag)._
 
 # Contribution
 Please read [Contribution](CONTRIBUTIONG.md)


### PR DESCRIPTION
Documentation didn't indicate needing to establish the ICINGA2_VERSION environment variable resulting in builds failing.

Added to Makefile with default "latest" & updated documentation.