### PR TITLE
Fixed DNS lookups where domain search is needed

### DIFF
--- a/rootfs/init/wait_for/dns.sh
+++ b/rootfs/init/wait_for/dns.sh
@@ -6,9 +6,7 @@ wait_for_dns() {
 
   until [[ ${retry} -le 0 ]]
   do
-    host=$(dig +noadditional +noqr +noquestion +nocmd +noauthority +nostats +nocomments ${server} | wc -l)
-
-    if [[ $host -eq 0 ]]
+    if ! host ${server} >/dev/null
     then
       retry=$(expr ${retry} - 1)
       sleep 10s


### PR DESCRIPTION
The tool `dig` ignores the search domains from `resolv.conf`. When using this tool, you have to always write the FQDN for every domain, instead of just for example `mysql`.

Just an idea: Writing some log messages when a "wait for" operation is still in progress. Makes debugging much more easy...