### PR TITLE
Using chmod +s if setcap fails

### DIFF
--- a/build/installer.sh
+++ b/build/installer.sh
@@ -160,17 +160,17 @@ fix_sys_caps() {
   # which allows us to make our binaries working without the
   # setuid bit
   if command -v setcap > /dev/null; then
-    if setcap "cap_net_raw+ep" ${plugindir}/check_icmp "cap_net_bind_service=+ep cap_net_raw=+ep" ${plugindir}/check_dhcp
+    if setcap "cap_net_raw+ep" /bin/ping "cap_net_raw+ep" ${plugindir}/check_icmp "cap_net_bind_service=+ep cap_net_raw=+ep" ${plugindir}/check_dhcp
     then
-      echo "setcap for check_icmp and check_dhcp worked!"
+      echo "setcap for ping, check_icmp and check_dhcp worked!"
     else
-      echo "setcap for check_icmp and check_dhcp failed." >&2
-      echo "Please refer README.Debian.gz for using plugins needing" >&2
-      echo "higher privileges!" >&2
+      echo "setcap for ping, check_icmp and check_dhcp failed," >&2
+      echo "using SETUID instead" >&2
+      chmod +s /bin/ping ${plugindir}/check_icmp ${plugindir}/check_dhcp
     fi
   else
-    echo "setcap is not installed, please refer README.Debian.gz for using" >&2
-    echo "plugins needing higher privileges!" >&2
+    echo "setcap is not installed, using SETUID instead" >&2
+    chmod +s /bin/ping ${plugindir}/check_icmp ${plugindir}/check_dhcp
   fi
 }
 

--- a/rootfs/init/common.sh
+++ b/rootfs/init/common.sh
@@ -163,20 +163,19 @@ fix_sys_caps() {
   # which allows us to make our binaries working without the
   # setuid bit
   if command -v setcap > /dev/null; then
-    if setcap "cap_net_raw+ep" ${plugindir}/check_icmp "cap_net_bind_service=+ep cap_net_raw=+ep" ${plugindir}/check_dhcp
+    if setcap "cap_net_raw+ep" /bin/ping "cap_net_raw+ep" ${plugindir}/check_icmp "cap_net_bind_service=+ep cap_net_raw=+ep" ${plugindir}/check_dhcp
     then
-      echo "setcap for check_icmp and check_dhcp worked!"
+      echo "setcap for ping, check_icmp and check_dhcp worked!"
     else
-      echo "setcap for check_icmp and check_dhcp failed." >&2
-      echo "Please refer README.Debian.gz for using plugins needing" >&2
-      echo "higher privileges!" >&2
+      echo "setcap for ping, check_icmp and check_dhcp failed," >&2
+      echo "using SETUID instead" >&2
+      chmod +s /bin/ping ${plugindir}/check_icmp ${plugindir}/check_dhcp
     fi
   else
-    echo "setcap is not installed, please refer README.Debian.gz for using" >&2
-    echo "plugins needing higher privileges!" >&2
+    echo "setcap is not installed, using SETUID instead" >&2
+    chmod +s /bin/ping ${plugindir}/check_icmp ${plugindir}/check_dhcp
   fi
 }
-
 
 # enable Icinga2 Feature
 #


### PR DESCRIPTION
If using capabilities does not work, falling back to SETUID.

```
sh-4.4# sed -i "s#nagios:/bin/false#nagios:/bin/sh#" /etc/passwd
sh-4.4# su - nagios
$ ls -la /bin/ping /usr/lib/nagios/plugins/check_icmp /usr/lib/nagios/plugins/check_dhcp 
-rwsr-sr-x 1 root root 61240 Nov 10  2016 /bin/ping
-rwsr-sr-x 1 root root 59952 Jan 19  2017 /usr/lib/nagios/plugins/check_dhcp
-rwsr-sr-x 1 root root 63728 Jan 19  2017 /usr/lib/nagios/plugins/check_icmp
$ /bin/ping -n -U -w 30 -c 5 127.0.0.1
PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.041 ms
64 bytes from 127.0.0.1: icmp_seq=2 ttl=64 time=0.046 ms
64 bytes from 127.0.0.1: icmp_seq=3 ttl=64 time=0.053 ms
64 bytes from 127.0.0.1: icmp_seq=4 ttl=64 time=0.052 ms
64 bytes from 127.0.0.1: icmp_seq=5 ttl=64 time=0.052 ms

--- 127.0.0.1 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 3998ms
rtt min/avg/max/mdev = 0.041/0.048/0.053/0.009 ms
$ /usr/lib/nagios/plugins/check_icmp 127.0.0.1
OK - 127.0.0.1: rta 0.019ms, lost 0%|rta=0.019ms;200.000;500.000;0; pl=0%;40;80;; rtmax=0.051ms;;;; rtmin=0.008ms;;;; 
```