### PR TITLE
TICKET_SALT was defined but not used, fixes agent setups

### DIFF
--- a/rootfs/init/cert/certificate_handler.sh
+++ b/rootfs/init/cert/certificate_handler.sh
@@ -34,6 +34,7 @@ create_ca() {
   sed -i \
     -e "s|^.*\ NodeName\ \=\ .*|const\ NodeName\ \=\ \"${HOSTNAME}\"|g" \
     -e "s|^.*\ ZoneName\ \=\ .*|const\ ZoneName\ \=\ \"${HOSTNAME}\"|g" \
+    -e "s|^.*\ TicketSalt\ \=\ .*|const\ TicketSalt\ \=\ \"${TICKET_SALT}\"|g" \
     /etc/icinga2/constants.conf
 
   # icinga2 API cert - regenerate new private key and certificate when running in a new container


### PR DESCRIPTION
Hi,
i found a small one inside the certificate handler. After changing this, i don't need to do "icinga2 ca sign ..." anymore to get my clients started.