### PR TITLE
hostname can't be set in k8s so allow presetting it

### DIFF
--- a/rootfs/init/environment.sh
+++ b/rootfs/init/environment.sh
@@ -2,7 +2,8 @@
 # read and handle all needed environment variables
 #
 
-HOSTNAME=$(hostname -f)
+HOSTNAMEFQDN=$(hostname -f)
+HOSTNAME=${ICINGA2_MASTER:-${HOSTNAMEFQDN}}
 
 DEBUG=${DEBUG:-0}
 DEVELOPMENT_MODUS=${DEVELOPMENT_MODUS:-0}


### PR DESCRIPTION
K8S does not allow to set hostnames. Allow to preset it with ICINGA2_MASTER,
If not set, it falls back to current behaviour and nothing breaks.